### PR TITLE
Ommiting inproper adding array element to empty string

### DIFF
--- a/classes/cssmgr.php
+++ b/classes/cssmgr.php
@@ -1118,7 +1118,7 @@ function _mergeBorders(&$b, &$a) {	// Merges $a['BORDER-TOP-STYLE'] to $b['BORDE
 function MergeCSS($inherit,$tag,$attr) {
 	$p = array();
 	$zp = array();
-
+	$attr = (array)$attr;
 	$classes = array();
 	if (isset($attr['CLASS'])) {
 		$classes = preg_split('/\s+/',$attr['CLASS']);


### PR DESCRIPTION
It avoids inproper index value, while adding CLASS or ID elements to empty $attr.